### PR TITLE
Add backlight support

### DIFF
--- a/examples/ILI_GFX_FontTest/ILI_GFX_FontTest.ino
+++ b/examples/ILI_GFX_FontTest/ILI_GFX_FontTest.ino
@@ -9,18 +9,31 @@
 #include "RA8876_t3.h"
 #define RA8876_CS 10
 #define RA8876_RESET 9
-#define BACKLITE 7 //External backlight control connected to this Arduino pin
+//#define BACKLITE 7 //External backlight control connected to this Arduino pin
 RA8876_t3 tft = RA8876_t3(RA8876_CS, RA8876_RESET); //Using standard SPI pins
 
 void setup() {
+#ifdef BACKLITE
   pinMode(BACKLITE, OUTPUT);
   digitalWrite(BACKLITE, HIGH);
-
+#endif
   Serial.begin(38400);
   long unsigned debug_start = millis ();
   while (!Serial && ((millis () - debug_start) <= 5000)) ;
   Serial.println("Setup");
   tft.begin();
+
+#ifndef BACKLITE
+  tft.backlight(true);
+  tft.fillScreen(RED);
+  delay(2000);
+  tft.pwm0_Duty(0x0000);
+  delay(2000);
+  tft.pwm0_Duty(0x0ff0);
+  delay(2000);
+  tft.pwm0_Duty(0xffff);
+  delay(2000);
+#endif
 
   //tft.setRotation(1);
   tft.fillScreen(BLACK);

--- a/src/RA8876_t3.cpp
+++ b/src/RA8876_t3.cpp
@@ -955,15 +955,48 @@ ru16	Auto_Refresh;
 //**************************************************************//
 // Turn Display ON/Off (true = ON)
 //**************************************************************//
- void RA8876_t3::displayOn(boolean on)
- {
+void RA8876_t3::displayOn(boolean on)
+{
   if(on)
    lcdRegDataWrite(RA8876_DPCR, XPCLK_INV<<7|RA8876_DISPLAY_ON<<6|RA8876_OUTPUT_RGB);
   else
    lcdRegDataWrite(RA8876_DPCR, XPCLK_INV<<7|RA8876_DISPLAY_OFF<<6|RA8876_OUTPUT_RGB);
    
   delay(20);
- }
+}
+
+//**************************************************************//
+//**************************************************************//
+// Turn Backlight ON/Off (true = ON)
+//**************************************************************//
+void RA8876_t3::backlight(boolean on)
+{
+
+  if(on) {
+	//Enable_PWM0_Interrupt();
+	//Clear_PWM0_Interrupt_Flag();
+ 	//Mask_PWM0_Interrupt_Flag();
+	//Select_PWM0_Clock_Divided_By_2();
+ 	//Select_PWM0();
+ 	pwm_ClockMuxReg(0, RA8876_PWM_TIMER_DIV2, 0, RA8876_XPWM0_OUTPUT_PWM_TIMER0);
+ 	//Enable_PWM0_Dead_Zone();
+	//Auto_Reload_PWM0();
+	//Start_PWM0();
+	pwm_Configuration(RA8876_PWM_TIMER1_INVERTER_OFF, RA8876_PWM_TIMER1_AUTO_RELOAD,RA8876_PWM_TIMER1_STOP,
+					RA8876_PWM_TIMER0_DEAD_ZONE_ENABLE, RA8876_PWM_TIMER1_INVERTER_OFF,
+					RA8876_PWM_TIMER0_AUTO_RELOAD, RA8876_PWM_TIMER0_START);
+
+	pwm0_Duty(0xffff);
+
+  }
+  else 
+  {
+	pwm_Configuration(RA8876_PWM_TIMER1_INVERTER_OFF, RA8876_PWM_TIMER1_AUTO_RELOAD,RA8876_PWM_TIMER1_STOP,
+					RA8876_PWM_TIMER0_DEAD_ZONE_ENABLE, RA8876_PWM_TIMER1_INVERTER_OFF,
+					RA8876_PWM_TIMER0_AUTO_RELOAD, RA8876_PWM_TIMER0_STOP);
+
+  }
+}
 
 //**************************************************************//
 //**************************************************************//

--- a/src/RA8876_t3.h
+++ b/src/RA8876_t3.h
@@ -163,6 +163,7 @@ public:
 	
 	// Display
 	void displayOn(boolean on);
+	void backlight(boolean on);
 	void lcdHorizontalWidthVerticalHeight(ru16 width,ru16 height);
 	void lcdHorizontalNonDisplay(ru16 numbers);
 	void lcdHsyncStartPosition(ru16 numbers);


### PR DESCRIPTION
@mjs513  - Got the backlight to work...  See what you think

Added the backlight support.  A lot of it came from the example code up on BuyDisplay.com for the display.

Example sketch updated allow me to turn on and to change the pwm brightness for test.

Warning: I scratched my head some yesterday, as nothing worked.  But then found jumpers were set for External on my display.  So un-jumperd J27 and Jumpred J28 and it worked!